### PR TITLE
Fix travis badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Deeplink parser library
 
-[![Build Status](https://travis-ci.org/hellofresh/android-deeplink.svg?branch=master)](https://travis-ci.org/hellofresh/android-deeplink)
+[![Build Status](https://travis-ci.com/hellofresh/android-deeplink.svg?branch=master)](https://travis-ci.com/hellofresh/android-deeplink)
 
 ## Sample usage
 The most important entry points are the `DeepLinkParser<T>` and `BaseRoute<T>` classes.


### PR DESCRIPTION
The existing URL seem to be pointing to an invalid project.

This PR intends to fix that