### PR TITLE
Improve path matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 
 ## [Unreleased]
+- Improved path matching.
+  - Route pattern with/without trailing slash now matches URI with/without trailing slash.
+  - Named/nameless parameters now ignore empty path segments at the end of a URI. 
+  However, empty segments occurring before non-empty ones are still processed accordingly
+- Changed visibility of `MatchResult` to `internal`.
 
 ## [0.1.0] - 2019-01-17
 ### Added

--- a/deeplink/src/main/java/com/hellofresh/deeplink/BaseRoute.kt
+++ b/deeplink/src/main/java/com/hellofresh/deeplink/BaseRoute.kt
@@ -46,13 +46,14 @@ abstract class BaseRoute<out T>(private vararg val routes: String) : Action<T> {
     }
 
     private fun retrieveHostAndPathSegments(uri: DeepLinkUri): Pair<String, List<String>> {
+        val trimmedPathSegments = uri.pathSegments().dropLastWhile { it.isEmpty() }
         if (treatHostAsPath(uri)) {
             val pathSegments = ArrayList<String>(uri.pathSize() + 1)
             pathSegments.add(uri.host())
-            pathSegments.addAll(uri.pathSegments())
+            pathSegments.addAll(trimmedPathSegments)
             return "" to pathSegments
         }
-        return uri.host() to uri.pathSegments()
+        return uri.host() to trimmedPathSegments
     }
 
     /**

--- a/deeplink/src/main/java/com/hellofresh/deeplink/MatchResult.kt
+++ b/deeplink/src/main/java/com/hellofresh/deeplink/MatchResult.kt
@@ -16,4 +16,4 @@
 
 package com.hellofresh.deeplink
 
-class MatchResult(val isMatch: Boolean, val params: Map<String, String> = emptyMap())
+internal class MatchResult(val isMatch: Boolean, val params: Map<String, String> = emptyMap())

--- a/deeplink/src/test/java/com/hellofresh/deeplink/BaseRouteTest.kt
+++ b/deeplink/src/test/java/com/hellofresh/deeplink/BaseRouteTest.kt
@@ -25,6 +25,84 @@ import kotlin.test.assertTrue
 class BaseRouteTest {
 
     @Test
+    fun matchWith_pathVariations() {
+        var uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes")
+        assertTrue(TestRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/")
+        assertTrue(TestRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/x")
+        assertFalse(TestRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe/1234")
+        assertTrue(TestRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe/")
+        assertFalse(TestRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("hellofresh://host/recipes")
+        assertTrue(TestRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("hellofresh://host/recipes/")
+        assertTrue(TestRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("hellofresh://host/recipes/x")
+        assertFalse(TestRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("hellofresh://host/recipe/1234")
+        assertTrue(TestRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("hellofresh://host/recipe/")
+        assertFalse(TestRoute.matchWith(uri).isMatch)
+    }
+
+    @Test
+    fun matchWith_pathVariationsWithOverride() {
+        var uri = DeepLinkUri.parse("hellofresh://recipes")
+        assertTrue(PathOverrideRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("hellofresh://recipes/")
+        assertTrue(PathOverrideRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("hellofresh://recipes/x")
+        assertFalse(PathOverrideRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("hellofresh://recipe/1234")
+        assertTrue(PathOverrideRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("hellofresh://recipe/")
+        assertFalse(PathOverrideRoute.matchWith(uri).isMatch)
+    }
+
+    @Test
+    fun matchWith_pathVariationsWithNamelessParameter() {
+        var uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/x/1234")
+        assertTrue(NamelessPathRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes//1234")
+        assertTrue(NamelessPathRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/")
+        assertFalse(NamelessPathRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes//")
+        assertFalse(NamelessPathRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe/x")
+        assertTrue(NamelessPathRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe/1234")
+        assertTrue(NamelessPathRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe/")
+        assertFalse(NamelessPathRoute.matchWith(uri).isMatch)
+
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe")
+        assertFalse(NamelessPathRoute.matchWith(uri).isMatch)
+    }
+
+    @Test
     fun matchWith_UriWithNullQueryValue_ThrowsException() {
         assertFailsWith<IllegalStateException> {
             val uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe/1234?q")
@@ -99,12 +177,12 @@ class BaseRouteTest {
         assertTrue(NamelessPathRoute.matchWith(uri).isMatch)
     }
 
-    object TestRoute : BaseRoute<Unit>("recipe/:id") {
+object TestRoute : BaseRoute<Unit>("recipes", "recipe/:id") {
 
-        override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
-    }
+    override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
+}
 
-    object PathOverrideRoute : BaseRoute<Unit>("recipe/:id") {
+    object PathOverrideRoute : BaseRoute<Unit>("recipes", "recipe/:id") {
 
         override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
 
@@ -113,7 +191,7 @@ class BaseRouteTest {
         }
     }
     
-    object NamelessPathRoute : BaseRoute<Unit>("recipes/*/:id") {
+    object NamelessPathRoute : BaseRoute<Unit>("recipe/*", "recipes/*/:id") {
 
         override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
     }


### PR DESCRIPTION
Fixes #45 
Fixes #46 

**Description**
- Route pattern without trailing slash now matches URI with/without trailing slash
- Named/nameless parameters now match only non-empty URI path segments
  - With the exception of empty path segments between non-empty ones