### PR TITLE
Implements initial support for regex matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Added SNAPSHOT releases to JFrog
 - Added handler resolution section to README
+- Support for simple regex path matching
 
 ### Fixed
 - Ensure that routes are always selected in order of registration

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ This is a static string defined at compile time that must be exactly the same as
 2. **Wildcard (\*)**:
 This is quite straightforward, as the wildcard always passes unconditionally
 
-3. **Parameterized string**:
-This is a simple word that starts with a `:`. Similar to wildcard, it also passes unconditionally.
-The word will later be used as the key in the param map, and the corresponding URI part as its value.
+3. **Parameterized string**: `:parameterName(REGEX)`  
+Simple regexes are officially supported, however, the library does not attempt any sophisticated logic, hence complex regexes are highly discouraged.  
+The `REGEX` is matched against the entire URI part and if successful, `parameterName` will be stored as a key in the param map, and the corresponding URI part as its value
+  - `(REGEX)` is optional, and omitting it makes the syntax like `:parameterName`. This is basically equivalent to `:parameterName(.*)` and it passes unconditionally, just like the wildcard.  
+  - `parameterName` can be omitted as well in a situation where the regex matching functionality alone is required. The syntax then becomes `:(REGEX)`. Since there is no parameter name, the matched value will not be added to the param map.
 
 A Route can be configured such that it treats the host of the input deep link as the first part of the path segments. This can come handy for use with deep links made up of custom schemes and that do not necessarily define an explicit host.
 

--- a/deeplink/src/main/java/com/hellofresh/deeplink/BaseRoute.kt
+++ b/deeplink/src/main/java/com/hellofresh/deeplink/BaseRoute.kt
@@ -33,7 +33,8 @@ abstract class BaseRoute<out T>(private vararg val routes: String) : Action<T> {
                 when {
                     routePart.startsWith(":") -> {
                         val (key, value) = resolveParameterizedPath(routePart, inPart) ?: return@forEach
-                        params[key] = value
+                        val parameterKey = key.takeUnless { it.isEmpty() } ?: return@zip
+                        params[parameterKey] = value
                     }
                     routePart == "*" -> return@zip
                     routePart != inPart -> return@forEach

--- a/deeplink/src/main/java/com/hellofresh/deeplink/BaseRoute.kt
+++ b/deeplink/src/main/java/com/hellofresh/deeplink/BaseRoute.kt
@@ -68,7 +68,7 @@ abstract class BaseRoute<out T>(private vararg val routes: String) : Action<T> {
 
         val key = partialMatcher.group(1)
         val userPattern = partialMatcher.group(3) ?: return Pair(key, inPart)
-        val inputMatcher = Pattern.compile("^$userPattern$").matcher(inPart)
+        val inputMatcher = Pattern.compile(userPattern).matcher(inPart)
         if (!inputMatcher.matches()) return null
 
         return Pair(key, inPart)

--- a/deeplink/src/main/java/com/hellofresh/deeplink/BaseRoute.kt
+++ b/deeplink/src/main/java/com/hellofresh/deeplink/BaseRoute.kt
@@ -71,11 +71,7 @@ abstract class BaseRoute<out T>(private vararg val routes: String) : Action<T> {
         val inputMatcher = Pattern.compile("^$userPattern$").matcher(inPart)
         if (!inputMatcher.matches()) return null
 
-        val finalValue = when {
-            inputMatcher.groupCount() > 0 -> inputMatcher.group(1) // Picks the first group if exists
-            else -> inputMatcher.group() // Falls back to the entire string
-        }
-        return Pair(key, finalValue)
+        return Pair(key, inPart)
     }
 
     /**

--- a/deeplink/src/test/java/com/hellofresh/deeplink/BaseRouteTest.kt
+++ b/deeplink/src/test/java/com/hellofresh/deeplink/BaseRouteTest.kt
@@ -178,7 +178,7 @@ class BaseRouteTest {
     }
 
     @Test
-    fun matchWith_regexPathResolutionNoGrouping() {
+    fun matchWith_regexPathResolution() {
         var uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/detail/abc-1234")
         var res = RegexPathRoute.matchWith(uri)
         assertTrue(res.isMatch)
@@ -198,14 +198,6 @@ class BaseRouteTest {
         // id does not match
         uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/detail/1234")
         assertFalse(RegexPathRoute.matchWith(uri).isMatch)
-    }
-
-    @Test
-    fun matchWith_regexPathResolutionWithGrouping() {
-        val uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe/abc-1234")
-        val res = RegexPathRoute.matchWith(uri)
-        assertTrue(res.isMatch)
-        assertEquals("1234", res.params["id"])
     }
 
     @Test
@@ -235,7 +227,7 @@ class BaseRouteTest {
         override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
     }
 
-    object RegexPathRoute : BaseRoute<Unit>("recipes/:action(detail|info)/:id(.*-\\w+)", "recipe/:id(.*-(\\w+))") {
+    object RegexPathRoute : BaseRoute<Unit>("recipes/:action(detail|info)/:id(.*-\\w+)") {
 
         override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
     }

--- a/deeplink/src/test/java/com/hellofresh/deeplink/BaseRouteTest.kt
+++ b/deeplink/src/test/java/com/hellofresh/deeplink/BaseRouteTest.kt
@@ -208,6 +208,14 @@ class BaseRouteTest {
         assertEquals("1234", res.params["id"])
     }
 
+    @Test
+    fun matchWith_regexPathResolutionUnnamed() {
+        val uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe/abc-1234")
+        val res = UnnamedRegexPathRoute.matchWith(uri)
+        assertTrue(res.isMatch)
+        assertTrue(res.params.isEmpty())
+    }
+
     object TestRoute : BaseRoute<Unit>("recipes", "recipe/:id") {
 
         override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
@@ -228,6 +236,11 @@ class BaseRouteTest {
     }
 
     object RegexPathRoute : BaseRoute<Unit>("recipes/:action(detail|info)/:id(.*-\\w+)", "recipe/:id(.*-(\\w+))") {
+
+        override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
+    }
+
+    object UnnamedRegexPathRoute : BaseRoute<Unit>("recipe/:(.*-\\w+)") {
 
         override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
     }

--- a/deeplink/src/test/java/com/hellofresh/deeplink/BaseRouteTest.kt
+++ b/deeplink/src/test/java/com/hellofresh/deeplink/BaseRouteTest.kt
@@ -177,10 +177,41 @@ class BaseRouteTest {
         assertTrue(NamelessPathRoute.matchWith(uri).isMatch)
     }
 
-object TestRoute : BaseRoute<Unit>("recipes", "recipe/:id") {
+    @Test
+    fun matchWith_regexPathResolutionNoGrouping() {
+        var uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/detail/abc-1234")
+        var res = RegexPathRoute.matchWith(uri)
+        assertTrue(res.isMatch)
+        assertEquals("detail", res.params["action"])
+        assertEquals("abc-1234", res.params["id"])
 
-    override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
-}
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/info/abc-1234")
+        res = RegexPathRoute.matchWith(uri)
+        assertTrue(res.isMatch)
+        assertEquals("info", res.params["action"])
+        assertEquals("abc-1234", res.params["id"])
+
+        // action does not match
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/invalid/abc-1234")
+        assertFalse(RegexPathRoute.matchWith(uri).isMatch)
+
+        // id does not match
+        uri = DeepLinkUri.parse("http://www.hellofresh.com/recipes/detail/1234")
+        assertFalse(RegexPathRoute.matchWith(uri).isMatch)
+    }
+
+    @Test
+    fun matchWith_regexPathResolutionWithGrouping() {
+        val uri = DeepLinkUri.parse("http://www.hellofresh.com/recipe/abc-1234")
+        val res = RegexPathRoute.matchWith(uri)
+        assertTrue(res.isMatch)
+        assertEquals("1234", res.params["id"])
+    }
+
+    object TestRoute : BaseRoute<Unit>("recipes", "recipe/:id") {
+
+        override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
+    }
 
     object PathOverrideRoute : BaseRoute<Unit>("recipes", "recipe/:id") {
 
@@ -190,8 +221,13 @@ object TestRoute : BaseRoute<Unit>("recipes", "recipe/:id") {
             return uri.scheme() == "hellofresh"
         }
     }
-    
+
     object NamelessPathRoute : BaseRoute<Unit>("recipe/*", "recipes/*/:id") {
+
+        override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
+    }
+
+    object RegexPathRoute : BaseRoute<Unit>("recipes/:action(detail|info)/:id(.*-\\w+)", "recipe/:id(.*-(\\w+))") {
 
         override fun run(uri: DeepLinkUri, params: Map<String, String>, env: Environment) = Unit
     }


### PR DESCRIPTION
Closes #59 

**Syntax:**

`:parameterName(REGEX)`
Simple regexes are officially supported, however, the library doesn't try to do any sophisticated logic,
hence complex regexes should be avoided
`(REGEX)` can be omitted, which then makes it fall back to the already supported `:parameterName` syntax.
This is basically equivalent to `:parameterName(.*)`

Parameter name can be omitted if we're only interested in regex matching alone.
This then becomes `:(REGEX)`, and whatever the value is will not be added to the parameter map

**Note**: Multiple parameters in a single part is currently not supported